### PR TITLE
Use max index rather than table length

### DIFF
--- a/lua/autorun/gtask.lua
+++ b/lua/autorun/gtask.lua
@@ -213,6 +213,21 @@ task.Remove = task.Kill
 local run_timers = function()
     local curtime = CurTime()
     local length = max_table_number(stored)
+    if length > 1000 and length > #stored then --Rebase if we surpass 1000 "timers" and our length is greater than the actual table length, if what you're working on has more than 1000 real timers then idk what you're doing
+        local dummy_table = {}
+        for index, data in pairs(stored) do
+            dummy_table[#dummy_table + 1] = data
+        end
+
+        stored = {}
+        for index = 1, #dummy_table do
+            local data = dummy_table[index]
+            stored[index] = data
+        end
+
+        length = #stored
+    end
+
     for index = 1, length do
         CallTask(index, curtime)
     end

--- a/lua/autorun/gtask.lua
+++ b/lua/autorun/gtask.lua
@@ -213,7 +213,7 @@ task.Remove = task.Kill
 local next_check_time = 0
 local next_cycle_time = 0.25
 local function ValidifyTimers(curtime) --Check every 0.25 seconds to ensure our timers are valid relative to the functions
-    if collect_time >= curtime then return end
+    if next_check_time >= curtime then return end
     next_check_time = curtime + next_cycle_time
 
     local length = #stored

--- a/lua/autorun/gtask.lua
+++ b/lua/autorun/gtask.lua
@@ -211,8 +211,8 @@ end
 task.Remove = task.Kill
 
 local next_check_time = 0
-local next_cycle_time = 0.25
-local function ValidifyTimers(curtime) --Check every 0.25 seconds to ensure our timers are valid relative to the functions
+local next_cycle_time = 0.05
+local function ValidifyTimers(curtime) --Check every 0.05 seconds to ensure our timers are valid relative to the functions
     if next_check_time >= curtime then return end
     next_check_time = curtime + next_cycle_time
 

--- a/lua/autorun/gtask.lua
+++ b/lua/autorun/gtask.lua
@@ -28,13 +28,13 @@ if gtask and (not gtask.version or gtask.version <= VERSION) then
     return
 end
 
-local CurTime, remove, unpack, assert, isnumber, isstring, isfunction = CurTime, table.remove, unpack, assert, isnumber, isstring, isfunction
+local CurTime, remove, unpack, assert, isnumber, isstring, isfunction, max_table_number = CurTime, table.remove, unpack, assert, isnumber, isstring, isfunction, table.maxn
 
 local task = {version = VERSION}
 local stored = {}
 
 local function NewTask(data)
-    local index = #stored + 1
+    local index = max_table_number(stored) + 1
 
     data.started = CurTime()
     data.paused = false
@@ -114,7 +114,7 @@ end
 ---@param name string
 ---@return table
 function task.Get(name)
-    local length = #stored
+    local length = max_table_number(stored)
     for index = 1, length do
         local data = stored[index]
         if data and data.name == name then
@@ -210,31 +210,9 @@ end
 
 task.Remove = task.Kill
 
-local next_check_time = 0
-local next_cycle_time = 0.05
-local function ValidifyTimers(curtime) --Check every 0.05 seconds to ensure our timers are valid relative to the functions
-    if next_check_time >= curtime then return end
-    next_check_time = curtime + next_cycle_time
-
-    local length = #stored
-    for index, data in pairs(stored) do
-        if index <= length then continue end --Our created task cannot be reached if we get past this
-
-        if data.infinite or data.repeats > 1 then
-            task.Create(data.name, data.time, data.repeats, data.func, unpack(data.args))
-        elseif not data.infinite and data.repeats == 1 then
-            task.Simple(data.time, data.func, unpack(data.args))
-        else
-            task.Remove(data.name)
-        end
-    end
-end
-
 local run_timers = function()
     local curtime = CurTime()
-    ValidifyTimers(curtime)
-
-    local length = #stored
+    local length = max_table_number(stored)
     for index = 1, length do
         CallTask(index, curtime)
     end

--- a/lua/autorun/gtask.lua
+++ b/lua/autorun/gtask.lua
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --]]
 
-local VERSION = 113
+local VERSION = 114
 
 if gtask and (not gtask.version or gtask.version <= VERSION) then
     return


### PR DESCRIPTION
Use max index in table rather than the table length to ensure we don't miss any timers and potentially have timers be sent to the netherrealm (realistically this won't cause performance issues and I even included some code to ensure it stays lean as a server runs)